### PR TITLE
Fix in_range?/1 to include boundary values

### DIFF
--- a/lib/is_chinese.ex
+++ b/lib/is_chinese.ex
@@ -21,8 +21,8 @@ defmodule IsChinese do
 
   defp in_range?(codepoint) do
     << int_val :: utf8 >> = codepoint
-    Enum.any? @chinese_range, fn(r) -> 
-      int_val > elem(r,0) && int_val < elem(r, 1)
+    Enum.any? @chinese_range, fn(r) ->
+      int_val >= elem(r,0) && int_val <= elem(r, 1)
     end
   end
 end

--- a/test/is_chinese_test.exs
+++ b/test/is_chinese_test.exs
@@ -7,5 +7,6 @@ defmodule IsChineseTest do
     assert IsChinese.verify?("a你好")  == false
     assert IsChinese.verify?("abc")  == false
     assert IsChinese.verify?("中国ssabc")  == false
+    assert IsChinese.verify?("一") == true
   end
 end


### PR DESCRIPTION
Currently, boundary values of each block are excluded but they have to be included (e.g. `0x4e00`, a minimum value of CJK Unified Ideographs, stands for a very common Chinese character "一").

As for original implementation of this library, it includes these values properly. 
https://github.com/alsotang/is-chinese/blob/master/lib/is_chinese.js#L30

## Current behavior
```elixir
iex(1)> IsChinese.verify?("一")
false
```

## Expected behavior
```elixir
iex(1)> IsChinese.verify?("一")
true
```